### PR TITLE
:ambulance: Fix docker-compose file.

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb
+    image: mariadb:10.11.4
     command: '--default-authentication-plugin=mysql_native_password --init-file /data/application/init.sql'
     restart: always
     healthcheck:


### PR DESCRIPTION
Our container health check was not working with the latest version of MariaDB docker image.

I think this should be investigated and, if needed, we should open an issue on their codebase.

Anyway I've put a specific version (`10.11.4`) which is also the best practice to deploy it with Docker and ensure everything is always working as expected.