### PR TITLE
:sparkles: Implement routes with easy-route.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -9,3 +9,4 @@ Werkzeug==2.3.4
 toml==0.10.2
 mysql-connector-python==8.0.33
 validator-collection==1.5.0
+easy-route==0.0.2

--- a/app/stuquiz/controllers/admin/login_admin_controller.py
+++ b/app/stuquiz/controllers/admin/login_admin_controller.py
@@ -2,10 +2,9 @@
 # @created 05/07/23
 from typing import Optional
 
-from flask import Response
-from validator_collection import checkers
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
 from app.stuquiz.models.admin.admin_model import AdminModel
 
 
@@ -14,16 +13,13 @@ class LoginAdminController(AbstractController):
     def __init__(self, admin_model: Optional[AdminModel] = None):
         self.admin_model = admin_model or AdminModel()
 
-    def execute(self, data: dict) -> Response:
+    def execute(self, request: Request) -> Response:
         """
-        :param data: a dict containing email and clear text password for the admin.
+        :param request:
         :return: HTTP Response.
         """
-        email = data['email']
-        clear_password = data['password']
-
-        if not checkers.is_email(email) or not clear_password:
-            return Response('', 400)
+        email = request.form['email']
+        clear_password = request.form['password']
 
         admin_id = self.admin_model.login_admin(email, clear_password)
 

--- a/app/stuquiz/controllers/admin/logout_admin_controller.py
+++ b/app/stuquiz/controllers/admin/logout_admin_controller.py
@@ -2,9 +2,9 @@
 # @created 11/07/23
 from typing import Optional
 
-from flask import Response
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
 from app.stuquiz.models.admin.admin_model import AdminModel
 
 
@@ -13,12 +13,10 @@ class LogoutAdminController(AbstractController):
     def __init__(self, admin_model: Optional[AdminModel] = None):
         self.admin_model = admin_model or AdminModel()
 
-    def execute(self, data: dict) -> Response:
+    def execute(self, request: Request) -> Response:
         """
-        :param data: An empty dict
+        :param request:
         :return: HTTPResponse
         """
-        if not self.admin_model.is_admin_logged_in():
-            return Response('', 401)
         self.admin_model.logout_admin()
         return Response('{}', 200)

--- a/app/stuquiz/controllers/course/add_course_controller.py
+++ b/app/stuquiz/controllers/course/add_course_controller.py
@@ -2,40 +2,28 @@
 # @created 19/07/23
 from typing import Optional
 
-from flask import Response
-from validator_collection import checkers
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
-from app.stuquiz.models.admin.admin_model import AdminModel
 from app.stuquiz.models.course.course_model import CourseModel
 from app.stuquiz.models.university.university_model import UniversityModel
 
 
 class AddCourseController(AbstractController):
-    def __init__(self, course_model: Optional[CourseModel] = None, admin_model: Optional[AdminModel] = None,
-                 university_model: Optional[UniversityModel] = None):
+    def __init__(self, course_model: Optional[CourseModel] = None, university_model: Optional[UniversityModel] = None):
         self.course_model = course_model or CourseModel()
-        self.admin_model = admin_model or AdminModel()
         self.university_model = university_model or UniversityModel()
 
-    def execute(self, data: dict) -> Response:
+    def execute(self, request: Request) -> Response:
         """
-        :param data: a dict containing the course information.
+        :param request:
         :return: HTTP Response
         """
-        if not self.admin_model.is_admin_logged_in():
-            return Response('', 401)
-
-        university_id = data['university_id'] if 'university_id' in data else None
-        name = data['name'] if 'name' in data else None
-        description = data['description'] if 'description' in data else None
-        professor_id = data['professor_id'] if 'professor_id' in data else None
-        code = data['code'] if 'code' in data else None
-
-        if not checkers.is_uuid(university_id) or not checkers.is_string(name) or not name \
-                or not checkers.is_string(description) or not description or not checkers.is_uuid(professor_id) \
-                or not checkers.is_string(code) or not code:
-            return Response('', 400)
+        university_id = request.form['university_id']
+        name = request.form['name']
+        description = request.form['description']
+        professor_id = request.form['professor_id']
+        code = request.form['code']
 
         if not self.university_model.get_university_by_id(university_id):
             return Response('', 400)

--- a/app/stuquiz/controllers/course/delete_course_controller.py
+++ b/app/stuquiz/controllers/course/delete_course_controller.py
@@ -2,33 +2,22 @@
 # @created 20/07/23
 from typing import Optional
 
-from flask import Response
-from validator_collection import checkers
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
-from app.stuquiz.models.admin.admin_model import AdminModel
 from app.stuquiz.models.course.course_model import CourseModel
 
 
 class DeleteCourseController(AbstractController):
-    def __init__(self, course_model: Optional[CourseModel] = None, admin_model: Optional[AdminModel] = None):
+    def __init__(self, course_model: Optional[CourseModel] = None):
         self.course_model = course_model or CourseModel()
-        self.admin_model = admin_model or AdminModel()
 
-    def execute(self, data: dict) -> Response:
+    def execute(self, request: Request) -> Response:
         """
-        :param data: a dict containing the course ID.
+        :param request:
         :return: HTTP Response
         """
-        if not self.admin_model.is_admin_logged_in():
-            return Response('', 401)
-
-        course_id = data['course_id'] if 'course_id' in data else None
-
-        if not checkers.is_uuid(course_id):
-            return Response('', 400)
-
-        course = self.course_model.get_course_by_id(course_id)
+        course = self.course_model.get_course_by_id(request.args['course_id'])
 
         if not course:
             return Response('', 404)

--- a/app/stuquiz/controllers/course/get_course_by_id_controller.py
+++ b/app/stuquiz/controllers/course/get_course_by_id_controller.py
@@ -3,10 +3,9 @@
 import json
 from typing import Optional
 
-from flask import Response
-from validator_collection import checkers
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
 from app.stuquiz.models.course.course_model import CourseModel
 
 
@@ -14,16 +13,12 @@ class GetCourseByIdController(AbstractController):
     def __init__(self, course_model: Optional[CourseModel] = None):
         self.course_model = course_model or CourseModel()
 
-    def execute(self, data: dict) -> Response:
+    def execute(self, request: Request) -> Response:
         """
-        :param data: a dict containing the course id
+        :param request:
         :return: HTTP Response
         """
-        course_id = data['course_id'] if 'course_id' in data else None
-
-        if not checkers.is_uuid(course_id):
-            return Response('', 400)
-        course = self.course_model.get_course_by_id(data['course_id'])
+        course = self.course_model.get_course_by_id(request.args['course_id'])
 
         if not course:
             return Response('', 404)

--- a/app/stuquiz/controllers/course/get_courses_by_category_controller.py
+++ b/app/stuquiz/controllers/course/get_courses_by_category_controller.py
@@ -3,10 +3,9 @@
 import json
 from typing import Optional
 
-from flask import Response
-from validator_collection import checkers
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
 from app.stuquiz.models.course.course_model import CourseModel
 
 
@@ -14,11 +13,11 @@ class GetCoursesByCategoryController(AbstractController):
     def __init__(self, course_model: Optional[CourseModel] = None):
         self.course_model = course_model or CourseModel()
 
-    def execute(self, data: dict) -> Response:
-        category_id = data['category_id'] if 'category_id' in data else None
-
-        if not checkers.is_uuid(category_id):
-            return Response('', 400)
-        courses = self.course_model.get_courses_by_category(data['category_id'])
+    def execute(self, request: Request) -> Response:
+        """
+        :param request:
+        :return: HTTP Response
+        """
+        courses = self.course_model.get_courses_by_category(request.args['category_id'])
         result = [course.dump() for course in courses]
         return Response(json.dumps(result), 200)

--- a/app/stuquiz/controllers/course/get_courses_by_professor_controller.py
+++ b/app/stuquiz/controllers/course/get_courses_by_professor_controller.py
@@ -3,10 +3,9 @@
 import json
 from typing import Optional
 
-from flask import Response
-from validator_collection import checkers
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
 from app.stuquiz.models.course.course_model import CourseModel
 
 
@@ -14,15 +13,11 @@ class GetCoursesByProfessorController(AbstractController):
     def __init__(self, course_model: Optional[CourseModel] = None):
         self.course_model = course_model or CourseModel()
 
-    def execute(self, data: dict) -> Response:
+    def execute(self, request: Request) -> Response:
         """
-        :param data: a dict containing the professor id
+        :param request:
         :return: HTTP Response
         """
-        professor_id = data['professor_id'] if 'professor_id' in data else None
-
-        if not checkers.is_uuid(professor_id):
-            return Response('', 400)
-        courses = self.course_model.get_courses_by_professor(data['professor_id'])
+        courses = self.course_model.get_courses_by_professor(request.args['professor_id'])
         result = [course.dump() for course in courses]
         return Response(json.dumps(result), 200)

--- a/app/stuquiz/controllers/course/get_courses_controller.py
+++ b/app/stuquiz/controllers/course/get_courses_controller.py
@@ -3,9 +3,9 @@
 import json
 from typing import Optional
 
-from flask import Response
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
 from app.stuquiz.models.course.course_model import CourseModel
 
 
@@ -13,9 +13,9 @@ class GetCoursesController(AbstractController):
     def __init__(self, course_model: Optional[CourseModel] = None):
         self.course_model = course_model or CourseModel()
 
-    def execute(self, data: dict) -> Response:
+    def execute(self, request: Request) -> Response:
         """
-        :param data: an empty dict
+        :param request:
         :return: HTTP Response
         """
         courses = self.course_model.get_courses()

--- a/app/stuquiz/controllers/course/update_course_controller.py
+++ b/app/stuquiz/controllers/course/update_course_controller.py
@@ -2,41 +2,29 @@
 # @created 20/07/23
 from typing import Optional
 
-from flask import Response
-from validator_collection import checkers
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
-from app.stuquiz.models.admin.admin_model import AdminModel
 from app.stuquiz.models.course.course_model import CourseModel
 from app.stuquiz.models.university.university_model import UniversityModel
 
 
 class UpdateCourseController(AbstractController):
-    def __init__(self, course_model: Optional[CourseModel] = None, admin_model: Optional[AdminModel] = None,
-                 university_model: Optional[UniversityModel] = None):
+    def __init__(self, course_model: Optional[CourseModel] = None, university_model: Optional[UniversityModel] = None):
         self.course_model = course_model or CourseModel()
-        self.admin_model = admin_model or AdminModel()
         self.university_model = university_model or UniversityModel()
 
-    def execute(self, data: dict) -> Response:
+    def execute(self, request: Request) -> Response:
         """
-        :param data: a dict containing the course information.
+        :param request:
         :return: HTTP Response
         """
-        if not self.admin_model.is_admin_logged_in():
-            return Response('', 401)
-
-        course_id = data['course_id'] if 'course_id' in data else None
-        university_id = data['university_id'] if 'university_id' in data else None
-        name = data['name'] if 'name' in data else None
-        description = data['description'] if 'description' in data else None
-        professor_id = data['professor_id'] if 'professor_id' in data else None
-        code = data['code'] if 'code' in data else None
-
-        if not checkers.is_uuid(course_id) or not checkers.is_uuid(university_id) or not checkers.is_string(name) \
-                or not name or not checkers.is_string(description) or not description \
-                or not checkers.is_uuid(professor_id) or not checkers.is_string(code) or not code:
-            return Response('', 400)
+        course_id = request.args['course_id']
+        university_id = request.form['university_id']
+        name = request.form['name']
+        description = request.form['description']
+        professor_id = request.form['professor_id']
+        code = request.form['code']
 
         if not self.course_model.get_course_by_id(course_id):
             return Response('', 404)

--- a/app/stuquiz/controllers/university/add_university_controller.py
+++ b/app/stuquiz/controllers/university/add_university_controller.py
@@ -2,34 +2,21 @@
 # @created 11/07/23
 from typing import Optional
 
-from flask import Response
-from validator_collection import checkers
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
-from app.stuquiz.models.admin.admin_model import AdminModel
 from app.stuquiz.models.university.university_model import UniversityModel
 
 
 class AddUniversityController(AbstractController):
-    def __init__(self, university_model: Optional[UniversityModel] = None,
-                 admin_model: Optional[AdminModel] = None):
+    def __init__(self, university_model: Optional[UniversityModel] = None):
         self.university_model = university_model or UniversityModel()
-        self.admin_model = admin_model or AdminModel()
 
-    def execute(self, data: dict) -> Response:
+    def execute(self, request: Request) -> Response:
         """
-        :param data: a dict containing the university name.
+        :param request:
         :return: HTTP Response
         """
-        if not self.admin_model.is_admin_logged_in():
-            return Response('', 401)
-
-        university_name = data['name'] if 'name' in data else None
-
-        if not checkers.is_string(university_name) or not university_name:
-            return Response('', 400)
-
-        if not self.university_model.add_university(university_name):
+        if not self.university_model.add_university(request.form['name']):
             return Response('', 500)
-
         return Response('{}', 200)

--- a/app/stuquiz/controllers/university/delete_university_controller.py
+++ b/app/stuquiz/controllers/university/delete_university_controller.py
@@ -2,33 +2,22 @@
 # @created 16/07/23
 from typing import Optional
 
-from flask import Response
-from validator_collection import checkers
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
-from app.stuquiz.models.admin.admin_model import AdminModel
 from app.stuquiz.models.university.university_model import UniversityModel
 
 
 class DeleteUniversityController(AbstractController):
-    def __init__(self, university_model: Optional[UniversityModel] = None,
-                 admin_model: Optional[AdminModel] = None):
+    def __init__(self, university_model: Optional[UniversityModel] = None):
         self.university_model = university_model or UniversityModel()
-        self.admin_model = admin_model or AdminModel()
 
-    def execute(self, data: dict) -> Response:
+    def execute(self, request: Request) -> Response:
         """
-        :param data: a dict containing the university id.
+        :param request:
         :return: HTTP Response
         """
-        if not self.admin_model.is_admin_logged_in():
-            return Response('', 401)
-
-        university_id = data['university_id'] if 'university_id' in data else None
-
-        if not checkers.is_uuid(university_id):
-            return Response('', 400)
-
+        university_id = request.args['university_id']
         university = self.university_model.get_university_by_id(university_id)
 
         if not university:

--- a/app/stuquiz/controllers/university/get_universities_controller.py
+++ b/app/stuquiz/controllers/university/get_universities_controller.py
@@ -3,9 +3,9 @@
 import json
 from typing import Optional
 
-from flask import Response
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
 from app.stuquiz.models.university.university_model import UniversityModel
 
 
@@ -13,9 +13,9 @@ class GetUniversitiesController(AbstractController):
     def __init__(self, university_model: Optional[UniversityModel] = None):
         self.university_model = university_model or UniversityModel()
 
-    def execute(self, data: dict) -> Response:
+    def execute(self, request: Request) -> Response:
         """
-        :param data: an empty dict
+        :param request:
         :return: HTTP Response
         """
         universities = self.university_model.get_universities()

--- a/app/stuquiz/controllers/university/get_university_by_id_controller.py
+++ b/app/stuquiz/controllers/university/get_university_by_id_controller.py
@@ -3,10 +3,9 @@
 import json
 from typing import Optional
 
-from flask import Response
-from validator_collection import checkers
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
 from app.stuquiz.models.university.university_model import UniversityModel
 
 
@@ -14,16 +13,12 @@ class GetUniversityByIdController(AbstractController):
     def __init__(self, university_model: Optional[UniversityModel] = None):
         self.university_model = university_model or UniversityModel()
 
-    def execute(self, data: dict) -> Response:
+    def execute(self, request: Request) -> Response:
         """
-        :param data: a dict containing the university id
+        :param request:
         :return: HTTP Response
         """
-        university_id = data['university_id']
-
-        if not checkers.is_uuid(university_id):
-            return Response('', 400)
-        university = self.university_model.get_university_by_id(data['university_id'])
+        university = self.university_model.get_university_by_id(request.args['university_id'])
 
         if not university:
             return Response('', 404)

--- a/app/stuquiz/controllers/university/get_university_courses_controller.py
+++ b/app/stuquiz/controllers/university/get_university_courses_controller.py
@@ -3,10 +3,9 @@
 import json
 from typing import Optional
 
-from flask import Response
-from validator_collection import checkers
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
 from app.stuquiz.models.university.university_model import UniversityModel
 
 
@@ -14,16 +13,12 @@ class GetUniversityCoursesController(AbstractController):
     def __init__(self, university_model: Optional[UniversityModel] = None):
         self.university_model = university_model or UniversityModel()
 
-    def execute(self, data: dict) -> Response:
+    def execute(self, request: Request) -> Response:
         """
-        :param data: a dict containing the university id.
+        :param request:
         :return: HTTP Response
         """
-        university_id = data['university_id'] if 'university_id' in data else None
-
-        if not checkers.is_uuid(university_id):
-            return Response('', 400)
-        university = self.university_model.get_university_by_id(data['university_id'])
+        university = self.university_model.get_university_by_id(request.args['university_id'])
 
         if not university:
             return Response('', 404)

--- a/app/stuquiz/controllers/university/update_university_controller.py
+++ b/app/stuquiz/controllers/university/update_university_controller.py
@@ -2,10 +2,9 @@
 # @created 12/07/23
 from typing import Optional
 
-from flask import Response
-from validator_collection import checkers
+from easy_route.controllers.abstract_controller import AbstractController
+from flask import Response, Request
 
-from app.stuquiz.controllers.abstract_controller import AbstractController
 from app.stuquiz.models.admin.admin_model import AdminModel
 from app.stuquiz.models.university.university_model import UniversityModel
 
@@ -16,26 +15,17 @@ class UpdateUniversityController(AbstractController):
         self.university_model = university_model or UniversityModel()
         self.admin_model = admin_model or AdminModel()
 
-    def execute(self, data: dict) -> Response:
+    def execute(self, request: Request) -> Response:
         """
-        :param data: a dict containing the university id and the new name.
+        :param request:
         :return: HTTP Response
         """
-        if not self.admin_model.is_admin_logged_in():
-            return Response('', 401)
-
-        university_id = data['university_id'] if 'university_id' in data else None
-        university_name = data['name'] if 'name' in data else None
-
-        if not checkers.is_string(university_name) or not university_name or not checkers.is_uuid(university_id):
-            return Response('', 400)
-
-        university = self.university_model.get_university_by_id(university_id)
+        university = self.university_model.get_university_by_id(request.args['university_id'])
 
         if not university:
             return Response('', 404)
 
-        university.name = university_name
+        university.name = request.form['name']
 
         if not self.university_model.update_university(university):
             return Response('', 500)

--- a/app/stuquiz/middlewares/__init__.py
+++ b/app/stuquiz/middlewares/__init__.py
@@ -1,0 +1,2 @@
+# @author Simone Nicol <en0mia.dev@gmail.com>
+# @created 24/07/23

--- a/app/stuquiz/middlewares/admin_login_middleware.py
+++ b/app/stuquiz/middlewares/admin_login_middleware.py
@@ -1,0 +1,24 @@
+# @author Simone Nicol <en0mia.dev@gmail.com>
+# @created 24/07/23
+from typing import Optional
+
+from easy_route.middlewares.abstract_middleware import AbstractMiddleware
+from flask import Request, Response
+
+from app.stuquiz.models.admin.admin_model import AdminModel
+
+
+class AdminLoginMiddleware(AbstractMiddleware):
+    """Checks if an admin is logged in."""
+    def __init__(self, admin_model: Optional[AdminModel] = None):
+        super().__init__()
+        self.admin_model = admin_model or AdminModel()
+
+    def dispatch(self, request: Request) -> Optional[Response]:
+        """Returns HTTP 401 if the admin is not logged in, None otherwise.
+        :param request: The route's request.
+        :return: Response | None
+        """
+        if not self.admin_model.is_admin_logged_in():
+            return Response('', 401)
+        return None

--- a/app/stuquiz/middlewares/data_providers/__init__.py
+++ b/app/stuquiz/middlewares/data_providers/__init__.py
@@ -1,0 +1,2 @@
+# @author Simone Nicol <en0mia.dev@gmail.com>
+# @created 26/07/23

--- a/app/stuquiz/middlewares/data_providers/args_data_provider.py
+++ b/app/stuquiz/middlewares/data_providers/args_data_provider.py
@@ -1,0 +1,12 @@
+# @author Simone Nicol <en0mia.dev@gmail.com>
+# @created 26/07/23
+from typing import Optional
+
+from easy_route.middlewares.data_validator_middleware import DataProvider
+from flask import Request
+
+
+class ArgsDataProvider(DataProvider):
+    """This Data provider extracts the data from request.args"""
+    def get_data(self, request: Request) -> Optional[dict]:
+        return request.args

--- a/app/stuquiz/middlewares/data_providers/form_data_provider.py
+++ b/app/stuquiz/middlewares/data_providers/form_data_provider.py
@@ -1,0 +1,12 @@
+# @author Simone Nicol <en0mia.dev@gmail.com>
+# @created 26/07/23
+from typing import Optional
+
+from easy_route.middlewares.data_validator_middleware import DataProvider
+from flask import Request
+
+
+class FormDataProvider(DataProvider):
+    """This Data provider extracts the data from request.form"""
+    def get_data(self, request: Request) -> Optional[dict]:
+        return request.form

--- a/app/stuquiz/routes/admin/login_admin.py
+++ b/app/stuquiz/routes/admin/login_admin.py
@@ -1,17 +1,23 @@
 # @author Simone Nicol <en0mia.dev@gmail.com>
 # @created 05/07/23
+from easy_route.middlewares.data_validator_middleware import DataValidatorMiddleware
+from easy_route.routes.route import Route
 from flask import Blueprint, request
+from validator_collection import checkers
 
 from app.stuquiz.controllers.admin.login_admin_controller import LoginAdminController
+from app.stuquiz.middlewares.data_providers.form_data_provider import FormDataProvider
 
 login_admin_page = Blueprint('login_admin', __name__)
+
+DATA_VALIDATION_RULES = {
+    'email': checkers.is_email,
+    'password': checkers.is_string
+}
 
 
 @login_admin_page.route('/admin/login', methods=['POST'])
 def login():
     """Defines the route to log an admin in."""
-    data = request.form
-    email = data['email'] if 'email' in data else None
-    password = data['password'] if 'password' in data else None
-
-    return LoginAdminController().execute({'email': email, 'password': password})
+    return Route(request, LoginAdminController())\
+        .add_middleware(DataValidatorMiddleware(DATA_VALIDATION_RULES, FormDataProvider())).dispatch()

--- a/app/stuquiz/routes/admin/logout_admin.py
+++ b/app/stuquiz/routes/admin/logout_admin.py
@@ -1,8 +1,10 @@
 # @author Simone Nicol <en0mia.dev@gmail.com>
 # @created 11/07/23
-from flask import Blueprint
+from easy_route.routes.route import Route
+from flask import Blueprint, request
 
 from app.stuquiz.controllers.admin.logout_admin_controller import LogoutAdminController
+from app.stuquiz.middlewares.admin_login_middleware import AdminLoginMiddleware
 
 logout_admin_page = Blueprint('logout_admin', __name__)
 
@@ -10,4 +12,4 @@ logout_admin_page = Blueprint('logout_admin', __name__)
 @logout_admin_page.route('/admin/logout', methods=['POST'])
 def logout():
     """Defines the route to log out an admin."""
-    return LogoutAdminController().execute({})
+    return Route(request, LogoutAdminController()).add_middleware(AdminLoginMiddleware()).dispatch()

--- a/app/stuquiz/routes/course/add_course.py
+++ b/app/stuquiz/routes/course/add_course.py
@@ -1,26 +1,28 @@
 # @author Simone Nicol <en0mia.dev@gmail.com>
 # @created 19/07/23
+from easy_route.middlewares.data_validator_middleware import DataValidatorMiddleware
+from easy_route.routes.route import Route
 from flask import Blueprint, request
+from validator_collection import checkers
 
 from app.stuquiz.controllers.course.add_course_controller import AddCourseController
+from app.stuquiz.middlewares.admin_login_middleware import AdminLoginMiddleware
+from app.stuquiz.middlewares.data_providers.form_data_provider import FormDataProvider
 
 add_course_page = Blueprint('add_course', __name__)
+
+DATA_VALIDATION_RULES = {
+    'university_id': checkers.is_uuid,
+    'name': lambda name: checkers.is_string(name) and name,
+    'description': lambda description: checkers.is_string(description) and description,
+    'professor_id': checkers.is_uuid,
+    'code': lambda code: checkers.is_string(code) and code
+}
 
 
 @add_course_page.route('/courses', methods=['PUT'])
 def add_course():
     """Defines the route to add a new course."""
-    data = request.form
-    university_id = data['university_id'] if 'university_id' in data else None
-    name = data['name'] if 'name' in data else None
-    description = data['description'] if 'description' in data else None
-    professor_id = data['professor_id'] if 'professor_id' in data else None
-    code = data['code'] if 'code' in data else None
-
-    return AddCourseController().execute({
-        'university_id': university_id,
-        'name': name,
-        'description': description,
-        'professor_id': professor_id,
-        'code': code
-    })
+    return Route(request, AddCourseController())\
+        .add_middlewares([AdminLoginMiddleware(), DataValidatorMiddleware(DATA_VALIDATION_RULES, FormDataProvider())])\
+        .dispatch()

--- a/app/stuquiz/routes/course/delete_course.py
+++ b/app/stuquiz/routes/course/delete_course.py
@@ -1,13 +1,24 @@
 # @author Simone Nicol <en0mia.dev@gmail.com>
 # @created 20/07/23
-from flask import Blueprint
+from easy_route.middlewares.data_validator_middleware import DataValidatorMiddleware
+from easy_route.routes.route import Route
+from flask import Blueprint, request
+from validator_collection import checkers
 
 from app.stuquiz.controllers.course.delete_course_controller import DeleteCourseController
+from app.stuquiz.middlewares.admin_login_middleware import AdminLoginMiddleware
+from app.stuquiz.middlewares.data_providers.args_data_provider import ArgsDataProvider
 
 delete_course_page = Blueprint('delete_course', __name__)
 
+DATA_VALIDATION_RULES = {
+    'course_id': checkers.is_uuid
+}
 
-@delete_course_page.route('/courses/<course_id>', methods=['DELETE'])
-def delete_course(course_id=None):
+
+@delete_course_page.route('/course', methods=['DELETE'])
+def delete_course():
     """Defines the route to delete a course."""
-    return DeleteCourseController().execute({'course_id': course_id})
+    return Route(request, DeleteCourseController())\
+        .add_middlewares([AdminLoginMiddleware(), DataValidatorMiddleware(DATA_VALIDATION_RULES, ArgsDataProvider())])\
+        .dispatch()

--- a/app/stuquiz/routes/course/get_course_by_id.py
+++ b/app/stuquiz/routes/course/get_course_by_id.py
@@ -1,13 +1,23 @@
 # @author Simone Nicol <en0mia.dev@gmail.com>
 # @created 18/07/23
-from flask import Blueprint
+from easy_route.middlewares.data_validator_middleware import DataValidatorMiddleware
+from easy_route.routes.route import Route
+from flask import Blueprint, request
+from validator_collection import checkers
 
 from app.stuquiz.controllers.course.get_course_by_id_controller import GetCourseByIdController
+from app.stuquiz.middlewares.data_providers.args_data_provider import ArgsDataProvider
 
 get_course_by_id_page = Blueprint('get_course_by_id_page', __name__)
 
+DATA_VALIDATION_RULES = {
+    'course_id': checkers.is_uuid
+}
 
-@get_course_by_id_page.route('/courses/<course_id>', methods=['GET'])
-def get_course_by_id(course_id=None):
+
+@get_course_by_id_page.route('/course', methods=['GET'])
+def get_course_by_id():
     """Defines the route to get a course by id."""
-    return GetCourseByIdController().execute({'course_id': course_id})
+    return Route(request, GetCourseByIdController()) \
+        .add_middlewares([DataValidatorMiddleware(DATA_VALIDATION_RULES, ArgsDataProvider())]) \
+        .dispatch()

--- a/app/stuquiz/routes/course/get_courses.py
+++ b/app/stuquiz/routes/course/get_courses.py
@@ -1,6 +1,7 @@
 # @author Simone Nicol <en0mia.dev@gmail.com>
 # @created 18/07/23
-from flask import Blueprint
+from easy_route.routes.route import Route
+from flask import Blueprint, request
 
 from app.stuquiz.controllers.course.get_courses_controller import GetCoursesController
 
@@ -10,4 +11,5 @@ get_courses_page = Blueprint('get_courses', __name__)
 @get_courses_page.route('/courses', methods=['GET'])
 def get_courses():
     """Defines the route to get the courses."""
-    return GetCoursesController().execute({})
+    return Route(request, GetCoursesController())\
+        .dispatch()

--- a/app/stuquiz/routes/course/get_courses_by_category.py
+++ b/app/stuquiz/routes/course/get_courses_by_category.py
@@ -1,13 +1,23 @@
 # @author Simone Nicol <en0mia.dev@gmail.com>
 # @created 19/07/23
-from flask import Blueprint
+from easy_route.middlewares.data_validator_middleware import DataValidatorMiddleware
+from easy_route.routes.route import Route
+from flask import Blueprint, request
+from validator_collection import checkers
 
 from app.stuquiz.controllers.course.get_courses_by_category_controller import GetCoursesByCategoryController
+from app.stuquiz.middlewares.data_providers.args_data_provider import ArgsDataProvider
 
 get_courses_by_category_page = Blueprint('get_courses_by_category_page', __name__)
 
+DATA_VALIDATION_RULES = {
+    'category_id': checkers.is_uuid
+}
 
-@get_courses_by_category_page.route('/courses/category/<category_id>', methods=['GET'])
-def get_course_by_category(category_id=None):
+
+@get_courses_by_category_page.route('/courses/category', methods=['GET'])
+def get_course_by_category():
     """Defines the route to get the courses by Category ID."""
-    return GetCoursesByCategoryController().execute({'category_id': category_id})
+    return Route(request, GetCoursesByCategoryController())\
+        .add_middleware(DataValidatorMiddleware(DATA_VALIDATION_RULES, ArgsDataProvider()))\
+        .dispatch()

--- a/app/stuquiz/routes/course/get_courses_by_professor.py
+++ b/app/stuquiz/routes/course/get_courses_by_professor.py
@@ -1,13 +1,23 @@
 # @author Simone Nicol <en0mia.dev@gmail.com>
 # @created 19/07/23
-from flask import Blueprint
+from easy_route.middlewares.data_validator_middleware import DataValidatorMiddleware
+from easy_route.routes.route import Route
+from flask import Blueprint, request
+from validator_collection import checkers
 
 from app.stuquiz.controllers.course.get_courses_by_professor_controller import GetCoursesByProfessorController
+from app.stuquiz.middlewares.data_providers.args_data_provider import ArgsDataProvider
 
 get_courses_by_professor_page = Blueprint('get_courses_by_professor_page', __name__)
 
+DATA_VALIDATION_RULES = {
+    'professor_id': checkers.is_uuid
+}
 
-@get_courses_by_professor_page.route('/courses/professor/<professor_id>', methods=['GET'])
-def get_course_by_professor(professor_id=None):
+
+@get_courses_by_professor_page.route('/courses/professor', methods=['GET'])
+def get_course_by_professor():
     """Defines the route to get the courses by Professor ID."""
-    return GetCoursesByProfessorController().execute({'professor_id': professor_id})
+    return Route(request, GetCoursesByProfessorController())\
+        .add_middleware(DataValidatorMiddleware(DATA_VALIDATION_RULES, ArgsDataProvider()))\
+        .dispatch()

--- a/app/stuquiz/routes/university/add_university.py
+++ b/app/stuquiz/routes/university/add_university.py
@@ -1,15 +1,24 @@
 # @author Simone Nicol <en0mia.dev@gmail.com>
 # @created 11/07/23
+from easy_route.middlewares.data_validator_middleware import DataValidatorMiddleware
+from easy_route.routes.route import Route
 from flask import Blueprint, request
+from validator_collection import checkers
 
 from app.stuquiz.controllers.university.add_university_controller import AddUniversityController
+from app.stuquiz.middlewares.admin_login_middleware import AdminLoginMiddleware
+from app.stuquiz.middlewares.data_providers.form_data_provider import FormDataProvider
 
 add_university_page = Blueprint('add_university', __name__)
+
+DATA_VALIDATION_RULES = {
+    'name': lambda name: checkers.is_string(name) and name
+}
 
 
 @add_university_page.route('/universities', methods=['PUT'])
 def add_university():
     """Defines the route to add a new universities."""
-    data = request.form
-    university_name = data['name'] if 'name' in data else None
-    return AddUniversityController().execute({'name': university_name})
+    return Route(request, AddUniversityController()) \
+        .add_middlewares([AdminLoginMiddleware(), DataValidatorMiddleware(DATA_VALIDATION_RULES, FormDataProvider())])\
+        .dispatch()

--- a/app/stuquiz/routes/university/delete_university.py
+++ b/app/stuquiz/routes/university/delete_university.py
@@ -1,13 +1,26 @@
 # @author Simone Nicol <en0mia.dev@gmail.com>
 # @created 16/07/23
-from flask import Blueprint
+from easy_route.middlewares.data_validator_middleware import DataValidatorMiddleware
+from easy_route.routes.route import Route
+from flask import Blueprint, request
+from validator_collection import checkers
 
 from app.stuquiz.controllers.university.delete_university_controller import DeleteUniversityController
+from app.stuquiz.middlewares.admin_login_middleware import AdminLoginMiddleware
+from app.stuquiz.middlewares.data_providers.args_data_provider import ArgsDataProvider
 
 delete_university_page = Blueprint('delete_university', __name__)
 
+DATA_VALIDATION_RULES = {
+    'university_id': checkers.is_uuid
+}
 
-@delete_university_page.route('/universities/<university_id>', methods=['DELETE'])
-def delete_university(university_id=None):
+
+@delete_university_page.route('/universities', methods=['DELETE'])
+def delete_university():
     """Defines the route to delete a university."""
-    return DeleteUniversityController().execute({'university_id': university_id})
+    return Route(request, DeleteUniversityController())\
+        .add_middlewares([
+            AdminLoginMiddleware(),
+            DataValidatorMiddleware(DATA_VALIDATION_RULES, ArgsDataProvider())
+        ]).dispatch()

--- a/app/stuquiz/routes/university/get_universities.py
+++ b/app/stuquiz/routes/university/get_universities.py
@@ -1,6 +1,7 @@
 # @author Simone Nicol <en0mia.dev@gmail.com>
 # @created 04/07/23
-from flask import Blueprint
+from easy_route.routes.route import Route
+from flask import Blueprint, request
 
 from app.stuquiz.controllers.university.get_universities_controller import GetUniversitiesController
 
@@ -10,4 +11,4 @@ get_universities_page = Blueprint('get_universities', __name__)
 @get_universities_page.route('/universities', methods=['GET'])
 def get_universities():
     """Defines the route to get the universities."""
-    return GetUniversitiesController().execute({})
+    return Route(request, GetUniversitiesController()).dispatch()

--- a/app/stuquiz/routes/university/get_university_by_id.py
+++ b/app/stuquiz/routes/university/get_university_by_id.py
@@ -1,13 +1,23 @@
 # @author Simone Nicol <en0mia.dev@gmail.com>
 # @created 04/07/23
-from flask import Blueprint
+from easy_route.middlewares.data_validator_middleware import DataValidatorMiddleware
+from easy_route.routes.route import Route
+from flask import Blueprint, request
+from validator_collection import checkers
 
 from app.stuquiz.controllers.university.get_university_by_id_controller import GetUniversityByIdController
+from app.stuquiz.middlewares.data_providers.args_data_provider import ArgsDataProvider
 
 get_university_by_id_page = Blueprint('get_university_by_id_page', __name__)
 
+DATA_VALIDATION_RULES = {
+    'university_id': checkers.is_uuid
+}
 
-@get_university_by_id_page.route('/universities/<university_id>', methods=['GET'])
-def get_university_by_id(university_id=None):
+
+@get_university_by_id_page.route('/university', methods=['GET'])
+def get_university_by_id():
     """Defines the route to get a university by id."""
-    return GetUniversityByIdController().execute({'university_id': university_id})
+    return Route(request, GetUniversityByIdController())\
+        .add_middleware(DataValidatorMiddleware(DATA_VALIDATION_RULES, ArgsDataProvider()))\
+        .dispatch()

--- a/app/stuquiz/routes/university/get_university_courses.py
+++ b/app/stuquiz/routes/university/get_university_courses.py
@@ -1,13 +1,22 @@
 # @author Simone Nicol <en0mia.dev@gmail.com>
 # @created 16/07/23
-from flask import Blueprint
+from easy_route.middlewares.data_validator_middleware import DataValidatorMiddleware
+from easy_route.routes.route import Route
+from flask import Blueprint, request
+from validator_collection import checkers
 
 from app.stuquiz.controllers.university.get_university_courses_controller import GetUniversityCoursesController
+from app.stuquiz.middlewares.data_providers.args_data_provider import ArgsDataProvider
 
 get_university_courses_page = Blueprint('get_university_courses', __name__)
 
+DATA_VALIDATION_RULES = {
+    'university_id': checkers.is_uuid
+}
 
-@get_university_courses_page.route('/universities/<university_id>/courses', methods=['GET'])
-def get_university_courses(university_id=None):
+
+@get_university_courses_page.route('/university/courses', methods=['GET'])
+def get_university_courses():
     """Defines the route to get the courses linked to a university."""
-    return GetUniversityCoursesController().execute({'university_id': university_id})
+    return Route(request, GetUniversityCoursesController())\
+        .add_middleware(DataValidatorMiddleware(DATA_VALIDATION_RULES, ArgsDataProvider())).dispatch()

--- a/app/stuquiz/routes/university/update_university.py
+++ b/app/stuquiz/routes/university/update_university.py
@@ -1,15 +1,29 @@
 # @author Simone Nicol <en0mia.dev@gmail.com>
 # @created 12/07/23
+from easy_route.middlewares.data_validator_middleware import DataValidatorMiddleware
+from easy_route.routes.route import Route
 from flask import Blueprint, request
+from validator_collection import checkers
 
 from app.stuquiz.controllers.university.update_university_controller import UpdateUniversityController
+from app.stuquiz.middlewares.admin_login_middleware import AdminLoginMiddleware
+from app.stuquiz.middlewares.data_providers.args_data_provider import ArgsDataProvider
+from app.stuquiz.middlewares.data_providers.form_data_provider import FormDataProvider
 
 update_university_page = Blueprint('update_university', __name__)
 
+DATA_VALIDATION_RULES = {
+    'university_id': checkers.is_uuid
+}
 
-@update_university_page.route('/universities/<university_id>', methods=['POST'])
-def update_university(university_id=None):
+
+@update_university_page.route('/university', methods=['POST'])
+def update_university():
     """Defines the route to update a university."""
-    data = request.form
-    university_name = data['name'] if 'name' in data else None
-    return UpdateUniversityController().execute({'name': university_name, 'university_id': university_id})
+    middlewares = [
+        AdminLoginMiddleware(),
+        DataValidatorMiddleware({'university_id': checkers.is_uuid}, ArgsDataProvider()),
+        DataValidatorMiddleware({'name': lambda name: checkers.is_string(name) and name}, FormDataProvider())
+    ]
+    return Route(request, UpdateUniversityController()) \
+        .add_middlewares(middlewares).dispatch()

--- a/app/tests/controllers/admin/test_login_admin_controller.py
+++ b/app/tests/controllers/admin/test_login_admin_controller.py
@@ -2,6 +2,7 @@
 # @created 05/07/23
 import unittest
 import uuid
+from unittest import mock
 from unittest.mock import MagicMock
 
 from app.stuquiz.controllers.admin.login_admin_controller import LoginAdminController
@@ -15,67 +16,39 @@ class TestLoginAdminController(unittest.TestCase):
     TEST_ADMIN = Admin(str(uuid.uuid4()), 'username', TEST_VALID_EMAIL, 'password', 'salt')
 
     def setUp(self) -> None:
+        self.request = MagicMock()
         self.admin_model = MagicMock()
         self.controller = LoginAdminController(self.admin_model)
+        self.form = mock.PropertyMock(return_value={'email': self.TEST_VALID_EMAIL, 'password': self.TEST_PASSWORD})
+        type(self.request).form = self.form
 
     def tearDown(self) -> None:
+        self.request = None
         self.admin_model = None
         self.controller = None
-
-    def testExecute_return400_whenInvalidEmail(self):
-        # Arrange
-        input_body = {'email': self.TEST_INVALID_EMAIL, 'password': self.TEST_PASSWORD}
-
-        # Act
-        result = self.controller.execute(input_body)
-
-        # Assert
-        self.admin_model.login_admin.assert_not_called()
-        self.assertEqual(400, result.status_code)
-
-    def testExecute_return400_whenEmptyPassword(self):
-        # Arrange
-        input_body = {'email': self.TEST_VALID_EMAIL, 'password': ''}
-
-        # Act
-        result = self.controller.execute(input_body)
-
-        # Assert
-        self.admin_model.login_admin.assert_not_called()
-        self.assertEqual(400, result.status_code)
-
-    def testExecute_return400_whenEmptyEmail(self):
-        # Arrange
-        input_body = {'email': '', 'password': self.TEST_PASSWORD}
-
-        # Act
-        result = self.controller.execute(input_body)
-
-        # Assert
-        self.admin_model.login_admin.assert_not_called()
-        self.assertEqual(400, result.status_code)
+        self.form = None
 
     def testExecute_return401_whenAdminDontExist(self):
         # Arrange
-        input_body = {'email': self.TEST_VALID_EMAIL, 'password': self.TEST_PASSWORD}
         self.admin_model.login_admin.return_value = None
 
         # Act
-        result = self.controller.execute(input_body)
+        result = self.controller.execute(self.request)
 
         # Assert
+        self.assertEqual(2, self.form.call_count)
         self.admin_model.login_admin.assert_called_once()
         self.assertEqual(401, result.status_code)
 
     def testExecute_return200_whenLoginSuccessful(self):
         # Arrange
-        input_body = {'email': self.TEST_VALID_EMAIL, 'password': self.TEST_PASSWORD}
         self.admin_model.login_admin.return_value = self.TEST_ADMIN
 
         # Act
-        result = self.controller.execute(input_body)
+        result = self.controller.execute(self.request)
 
         # Assert
+        self.assertEqual(2, self.form.call_count)
         self.admin_model.login_admin.assert_called_once()
         self.admin_model.store_session.assert_called_once()
         self.assertEqual(200, result.status_code)

--- a/app/tests/controllers/admin/test_logout_admin_controller.py
+++ b/app/tests/controllers/admin/test_logout_admin_controller.py
@@ -10,35 +10,24 @@ from app.stuquiz.controllers.admin.logout_admin_controller import LogoutAdminCon
 class TestLogoutAdminController(unittest.TestCase):
 
     def setUp(self) -> None:
+        self.request = MagicMock()
         self.admin_model = MagicMock()
         self.controller = LogoutAdminController(self.admin_model)
 
     def tearDown(self) -> None:
+        self.request = None
         self.admin_model = None
         self.controller = None
+        self.form = None
 
-    def testExecute_return401_whenNotLoggedIn(self):
+    def testExecute_return200_whenLoggedOut(self):
         # Arrange
-        self.admin_model.is_admin_logged_in.return_value = False
-
-        # Act
-        result = self.controller.execute({})
-
-        # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
-        self.admin_model.logout_admin.assert_not_called()
-        self.assertEqual(401, result.status_code)
-
-    def testExecute_return401_whenLoggedOut(self):
-        # Arrange
-        self.admin_model.is_admin_logged_in.return_value = True
         expected_result = {}
 
         # Act
-        result = self.controller.execute({})
+        result = self.controller.execute(self.request)
 
         # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
         self.admin_model.logout_admin.assert_called_once()
         self.assertEqual(200, result.status_code)
         self.assertEqual(expected_result, json.loads(result.data))

--- a/app/tests/controllers/course/test_delete_course_controller.py
+++ b/app/tests/controllers/course/test_delete_course_controller.py
@@ -3,6 +3,7 @@
 import json
 import unittest
 import uuid
+from unittest import mock
 from unittest.mock import MagicMock
 
 from app.stuquiz.controllers.course.delete_course_controller import DeleteCourseController
@@ -11,49 +12,29 @@ from app.tests.controllers.course.course_controllers_utils import CourseControll
 
 class TestDeleteCourseController(unittest.TestCase):
     def setUp(self) -> None:
+        self.request = MagicMock()
         self.course_model = MagicMock()
         self.admin_model = MagicMock()
-        self.controller = DeleteCourseController(self.course_model, self.admin_model)
+        self.controller = DeleteCourseController(self.course_model)
+        self.args = mock.PropertyMock(return_value={'course_id': str(uuid.uuid4())})
+        type(self.request).args = self.args
 
     def tearDown(self) -> None:
+        self.request = None
         self.course_model = None
         self.admin_model = None
         self.controller = None
-
-    def testExecute_return401_whenAdminNotLoggedIn(self):
-        # Arrange
-        self.admin_model.is_admin_logged_in.return_value = False
-
-        # Act
-        result = self.controller.execute({'course_id': str(uuid.uuid4())})
-
-        # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
-        self.course_model.delete_course.assert_not_called()
-        self.assertEqual(401, result.status_code)
-
-    def testExecute_return400_whenInvalidCourseId(self):
-        # Arrange
-        self.admin_model.is_admin_logged_in.return_value = True
-
-        # Act
-        result = self.controller.execute({'course_id': 'invalid id'})
-
-        # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
-        self.course_model.delete_course.assert_not_called()
-        self.assertEqual(400, result.status_code)
+        self.args = None
 
     def testExecute_return404_whenCourseDontExist(self):
         # Arrange
-        self.admin_model.is_admin_logged_in.return_value = True
         self.course_model.get_course_by_id.return_value = None
 
         # Act
-        result = self.controller.execute({'course_id': str(uuid.uuid4())})
+        result = self.controller.execute(self.request)
 
         # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
+        self.args.assert_called_once()
         self.course_model.get_course_by_id.assert_called_once()
         self.course_model.delete_course.assert_not_called()
         self.assertEqual(404, result.status_code)
@@ -61,15 +42,14 @@ class TestDeleteCourseController(unittest.TestCase):
     def testExecute_return500_whenDbError(self):
         # Arrange
         course = CourseControllersUtils.generate_courses(1)
-        self.admin_model.is_admin_logged_in.return_value = True
         self.course_model.delete_course.return_value = False
         self.course_model.get_course_by_id.return_value = course[0]
 
         # Act
-        result = self.controller.execute({'course_id': str(uuid.uuid4())})
+        result = self.controller.execute(self.request)
 
         # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
+        self.args.assert_called_once()
         self.course_model.delete_course.assert_called_once()
         self.assertEqual(500, result.status_code)
 
@@ -77,13 +57,12 @@ class TestDeleteCourseController(unittest.TestCase):
         # Arrange
         expected_body = {}
         self.course_model.delete_course.return_value = True
-        self.admin_model.is_admin_logged_in.return_value = True
 
         # Act
-        result = self.controller.execute({'course_id': str(uuid.uuid4())})
+        result = self.controller.execute(self.request)
 
         # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
+        self.args.assert_called_once()
         self.course_model.delete_course.assert_called_once()
         self.assertEqual(200, result.status_code)
         self.assertEqual(expected_body, json.loads(result.data))

--- a/app/tests/controllers/course/test_get_course_by_id_controller.py
+++ b/app/tests/controllers/course/test_get_course_by_id_controller.py
@@ -3,6 +3,7 @@
 import json
 import unittest
 import uuid
+from unittest import mock
 from unittest.mock import MagicMock
 
 from app.stuquiz.controllers.course.get_course_by_id_controller import GetCourseByIdController
@@ -11,32 +12,27 @@ from app.tests.controllers.course.course_controllers_utils import CourseControll
 
 class TestGetCourseByIdController(unittest.TestCase):
     def setUp(self) -> None:
+        self.request = MagicMock()
         self.course_model = MagicMock()
         self.controller = GetCourseByIdController(self.course_model)
+        self.args = mock.PropertyMock(return_value={'course_id': str(uuid.uuid4())})
+        type(self.request).args = self.args
 
     def tearDown(self) -> None:
+        self.request = None
         self.course_model = None
         self.controller = None
-
-    def testExecute_return400_whenInvalidCourseId(self):
-        # Arrange
-        self.course_model.get_course_by_id.return_value = None
-
-        # Act
-        result = self.controller.execute({'course_id': 'invalid id'})
-
-        # Assert
-        self.course_model.get_course_by_id.assert_not_called()
-        self.assertEqual(400, result.status_code)
+        self.args = None
 
     def testExecute_return404_whenCourseDontExist(self):
         # Arrange
         self.course_model.get_course_by_id.return_value = None
 
         # Act
-        result = self.controller.execute({'course_id': str(uuid.uuid4())})
+        result = self.controller.execute(self.request)
 
         # Assert
+        self.args.assert_called_once()
         self.course_model.get_course_by_id.assert_called_once()
         self.assertEqual(404, result.status_code)
 
@@ -47,9 +43,10 @@ class TestGetCourseByIdController(unittest.TestCase):
         self.course_model.get_course_by_id.return_value = course
 
         # Act
-        result = self.controller.execute({'course_id': course.id})
+        result = self.controller.execute(self.request)
 
         # Assert
+        self.args.assert_called_once()
         self.course_model.get_course_by_id.assert_called_once()
         self.assertEqual(200, result.status_code)
         self.assertEqual(expected_body, json.loads(result.data))

--- a/app/tests/controllers/course/test_get_courses_by_category_controller.py
+++ b/app/tests/controllers/course/test_get_courses_by_category_controller.py
@@ -3,6 +3,7 @@
 import json
 import unittest
 import uuid
+from unittest import mock
 from unittest.mock import MagicMock
 
 from app.stuquiz.controllers.course.get_courses_by_category_controller import GetCoursesByCategoryController
@@ -11,23 +12,17 @@ from app.tests.controllers.course.course_controllers_utils import CourseControll
 
 class TestGetCoursesByCategoryController(unittest.TestCase):
     def setUp(self) -> None:
+        self.request = MagicMock()
         self.course_model = MagicMock()
         self.controller = GetCoursesByCategoryController(self.course_model)
+        self.args = mock.PropertyMock(return_value={'category_id': str(uuid.uuid4())})
+        type(self.request).args = self.args
 
     def tearDown(self) -> None:
+        self.request = None
         self.course_model = None
         self.controller = None
-
-    def testExecute_return400_whenInvalidCategoryId(self):
-        # Arrange
-        self.course_model.get_courses_by_category.return_value = None
-
-        # Act
-        result = self.controller.execute({'category_id': 'invalid id'})
-
-        # Assert
-        self.course_model.get_courses_by_professor.assert_not_called()
-        self.assertEqual(400, result.status_code)
+        self.args = None
 
     def testExecute_return200_whenCoursesExist(self):
         # Arrange
@@ -36,9 +31,10 @@ class TestGetCoursesByCategoryController(unittest.TestCase):
         self.course_model.get_courses_by_category.return_value = courses
 
         # Act
-        result = self.controller.execute({'category_id': str(uuid.uuid4())})
+        result = self.controller.execute(self.request)
 
         # Assert
+        self.args.assert_called_once()
         self.course_model.get_courses_by_category.assert_called_once()
         self.assertEqual(200, result.status_code)
         self.assertEqual(expected_body, json.loads(result.data))
@@ -49,9 +45,10 @@ class TestGetCoursesByCategoryController(unittest.TestCase):
         self.course_model.get_courses_by_category.return_value = []
 
         # Act
-        result = self.controller.execute({'category_id': str(uuid.uuid4())})
+        result = self.controller.execute(self.request)
 
         # Assert
+        self.args.assert_called_once()
         self.course_model.get_courses_by_category.assert_called_once()
         self.assertEqual(200, result.status_code)
         self.assertEqual(expected_body, json.loads(result.data))

--- a/app/tests/controllers/course/test_get_courses_controller.py
+++ b/app/tests/controllers/course/test_get_courses_controller.py
@@ -10,10 +10,12 @@ from app.tests.controllers.course.course_controllers_utils import CourseControll
 
 class TestGetCoursesController(unittest.TestCase):
     def setUp(self) -> None:
+        self.request = MagicMock()
         self.course_model = MagicMock()
         self.controller = GetCoursesController(self.course_model)
 
     def tearDown(self) -> None:
+        self.request = None
         self.course_model = None
         self.controller = None
 
@@ -23,7 +25,7 @@ class TestGetCoursesController(unittest.TestCase):
         self.course_model.get_courses.return_value = []
 
         # Act
-        result = self.controller.execute({})
+        result = self.controller.execute(self.request)
 
         # Assert
         self.course_model.get_courses.assert_called_once()
@@ -37,7 +39,7 @@ class TestGetCoursesController(unittest.TestCase):
         self.course_model.get_courses.return_value = courses
 
         # Act
-        result = self.controller.execute({})
+        result = self.controller.execute(self.request)
 
         # Assert
         self.course_model.get_courses.assert_called_once()

--- a/app/tests/controllers/university/test_add_university_controller.py
+++ b/app/tests/controllers/university/test_add_university_controller.py
@@ -2,6 +2,7 @@
 # @created 11/07/23
 import json
 import unittest
+from unittest import mock
 from unittest.mock import MagicMock
 
 from app.stuquiz.controllers.university.add_university_controller import AddUniversityController
@@ -11,48 +12,29 @@ class TestAddUniversityController(unittest.TestCase):
     TEST_NAME = 'University name'
 
     def setUp(self) -> None:
+        self.request = MagicMock()
         self.university_model = MagicMock()
         self.admin_model = MagicMock()
-        self.controller = AddUniversityController(self.university_model, self.admin_model)
+        self.controller = AddUniversityController(self.university_model)
+        self.form = mock.PropertyMock(return_value={'name': self.TEST_NAME})
+        type(self.request).form = self.form
 
     def tearDown(self) -> None:
+        self.request = None
         self.university_model = None
         self.admin_model = None
         self.controller = None
-
-    def testExecute_return401_whenAdminNotLoggedIn(self):
-        # Arrange
-        self.admin_model.is_admin_logged_in.return_value = False
-
-        # Act
-        result = self.controller.execute({'name': self.TEST_NAME})
-
-        # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
-        self.university_model.add_university.assert_not_called()
-        self.assertEqual(401, result.status_code)
-
-    def testExecute_return400_whenAdminNotLoggedIn(self):
-        # Arrange
-
-        # Act
-        result = self.controller.execute({'name': ''})
-
-        # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
-        self.university_model.add_university.assert_not_called()
-        self.assertEqual(400, result.status_code)
+        self.form = None
 
     def testExecute_return500_whenDbError(self):
         # Arrange
-        self.admin_model.is_admin_logged_in.return_value = True
         self.university_model.add_university.return_value = False
 
         # Act
-        result = self.controller.execute({'name': self.TEST_NAME})
+        result = self.controller.execute(self.request)
 
         # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
+        self.form.assert_called_once()
         self.university_model.add_university.assert_called_once()
         self.assertEqual(500, result.status_code)
 
@@ -60,13 +42,12 @@ class TestAddUniversityController(unittest.TestCase):
         # Arrange
         expected_body = {}
         self.university_model.add_university.return_value = True
-        self.admin_model.is_admin_logged_in.return_value = True
 
         # Act
-        result = self.controller.execute({'name': self.TEST_NAME})
+        result = self.controller.execute(self.request)
 
         # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
+        self.form.assert_called_once()
         self.university_model.add_university.assert_called_once()
         self.assertEqual(200, result.status_code)
         self.assertEqual(expected_body, json.loads(result.data))

--- a/app/tests/controllers/university/test_delete_university_controller.py
+++ b/app/tests/controllers/university/test_delete_university_controller.py
@@ -3,6 +3,7 @@
 import json
 import unittest
 import uuid
+from unittest import mock
 from unittest.mock import MagicMock
 
 from app.stuquiz.controllers.university.delete_university_controller import DeleteUniversityController
@@ -13,78 +14,54 @@ class TestDeleteUniversityController(unittest.TestCase):
     TEST_UNIVERSITY = University(str(uuid.uuid4()), 'University Name')
 
     def setUp(self) -> None:
+        self.request = MagicMock()
         self.university_model = MagicMock()
-        self.admin_model = MagicMock()
-        self.controller = DeleteUniversityController(self.university_model, self.admin_model)
+        self.controller = DeleteUniversityController(self.university_model)
+        self.args = mock.PropertyMock(return_value={'university_id': self.TEST_UNIVERSITY.id})
+        type(self.request).args = self.args
 
     def tearDown(self) -> None:
+        self.request = None
         self.university_model = None
-        self.admin_model = None
         self.controller = None
-
-    def testExecute_return401_whenAdminNotLoggedIn(self):
-        # Arrange
-        self.admin_model.is_admin_logged_in.return_value = False
-
-        # Act
-        result = self.controller.execute({'university_id': self.TEST_UNIVERSITY.id})
-
-        # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
-        self.university_model.delete_university.assert_not_called()
-        self.assertEqual(401, result.status_code)
-
-    def testExecute_return400_whenInvalidUniversityId(self):
-        # Arrange
-        self.admin_model.is_admin_logged_in.return_value = True
-
-        # Act
-        result = self.controller.execute({'university_id': 'invalid university id'})
-
-        # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
-        self.university_model.delete_university.assert_not_called()
-        self.assertEqual(400, result.status_code)
+        self.args = None
 
     def testExecute_return404_whenUniversityDoesNotExist(self):
         # Arrange
-        self.admin_model.is_admin_logged_in.return_value = True
         self.university_model.get_university_by_id.return_value = None
 
         # Act
-        result = self.controller.execute({'university_id': self.TEST_UNIVERSITY.id})
+        result = self.controller.execute(self.request)
 
         # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
+        self.args.assert_called_once()
         self.university_model.delete_university.assert_not_called()
         self.assertEqual(404, result.status_code)
 
     def testExecute_return500_whenDbError(self):
         # Arrange
-        self.admin_model.is_admin_logged_in.return_value = True
         self.university_model.get_university_by_id.return_value = self.TEST_UNIVERSITY
         self.university_model.delete_university.return_value = False
 
         # Act
-        result = self.controller.execute({'university_id': self.TEST_UNIVERSITY.id})
+        result = self.controller.execute(self.request)
 
         # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
+        self.args.assert_called_once()
         self.university_model.delete_university.assert_called_once()
         self.assertEqual(500, result.status_code)
 
     def testExecute_return200_whenUniversityDeleted(self):
         # Arrange
-        self.admin_model.is_admin_logged_in.return_value = True
         self.university_model.get_university_by_id.return_value = self.TEST_UNIVERSITY
         self.university_model.delete_university.return_value = True
         expected_body = {}
 
         # Act
-        result = self.controller.execute({'university_id': self.TEST_UNIVERSITY.id})
+        result = self.controller.execute(self.request)
 
         # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
+        self.args.assert_called_once()
         self.university_model.delete_university.assert_called_once_with(self.TEST_UNIVERSITY)
         self.assertEqual(200, result.status_code)
         self.assertEqual(expected_body, json.loads(result.data))

--- a/app/tests/controllers/university/test_get_universities_controller.py
+++ b/app/tests/controllers/university/test_get_universities_controller.py
@@ -12,10 +12,12 @@ from app.stuquiz.entities.university import University
 class TestGetUniversitiesController(unittest.TestCase):
     def setUp(self) -> None:
         self.university_model = MagicMock()
+        self.request = MagicMock()
         self.controller = GetUniversitiesController(self.university_model)
 
     def tearDown(self) -> None:
         self.university_model = None
+        self.request = None
         self.controller = None
 
     def testExecute_return200WithEmptyBody_whenUniversitiesDontExist(self):
@@ -24,7 +26,7 @@ class TestGetUniversitiesController(unittest.TestCase):
         self.university_model.get_universities.return_value = []
 
         # Act
-        result = self.controller.execute({})
+        result = self.controller.execute(self.request)
 
         # Assert
         self.university_model.get_universities.assert_called_once()
@@ -42,7 +44,7 @@ class TestGetUniversitiesController(unittest.TestCase):
         self.university_model.get_universities.return_value = [first_university, second_university]
 
         # Act
-        result = self.controller.execute({})
+        result = self.controller.execute(self.request)
 
         # Assert
         self.university_model.get_universities.assert_called_once()

--- a/app/tests/controllers/university/test_get_university_by_id_controller.py
+++ b/app/tests/controllers/university/test_get_university_by_id_controller.py
@@ -3,6 +3,7 @@
 import json
 import unittest
 import uuid
+from unittest import mock
 from unittest.mock import MagicMock
 
 from app.stuquiz.controllers.university.get_university_by_id_controller import GetUniversityByIdController
@@ -14,10 +15,14 @@ class TestGetUniversitiesController(unittest.TestCase):
 
     def setUp(self) -> None:
         self.university_model = MagicMock()
+        self.request = MagicMock()
+        self.args = mock.PropertyMock(return_value={'university_id': self.TEST_UNIVERSITY.id})
+        type(self.request).args = self.args
         self.controller = GetUniversityByIdController(self.university_model)
 
     def tearDown(self) -> None:
         self.university_model = None
+        self.request = None
         self.controller = None
 
     def testExecute_return404_whenUniversityDontExist(self):
@@ -25,9 +30,10 @@ class TestGetUniversitiesController(unittest.TestCase):
         self.university_model.get_university_by_id.return_value = []
 
         # Act
-        result = self.controller.execute({'university_id': str(uuid.uuid4())})
+        result = self.controller.execute(self.request)
 
         # Assert
+        self.args.assert_called_once()
         self.university_model.get_university_by_id.assert_called_once()
         self.assertEqual(404, result.status_code)
 
@@ -37,19 +43,10 @@ class TestGetUniversitiesController(unittest.TestCase):
         self.university_model.get_university_by_id.return_value = self.TEST_UNIVERSITY
 
         # Act
-        result = self.controller.execute({'university_id': self.TEST_UNIVERSITY.id})
+        result = self.controller.execute(self.request)
 
         # Assert
+        self.args.assert_called_once()
         self.university_model.get_university_by_id.assert_called_once()
         self.assertEqual(200, result.status_code)
         self.assertEqual(expected_body, json.loads(result.data))
-
-    def testExecute_return400_whenUniversityIdIsNotValid(self):
-        # Arrange
-
-        # Act
-        result = self.controller.execute({'university_id': None})
-
-        # Assert
-        self.university_model.get_university_by_id.assert_not_called()
-        self.assertEqual(400, result.status_code)

--- a/app/tests/controllers/university/test_get_university_courses_controller.py
+++ b/app/tests/controllers/university/test_get_university_courses_controller.py
@@ -3,6 +3,7 @@
 import json
 import unittest
 import uuid
+from unittest import mock
 from unittest.mock import MagicMock
 
 from app.stuquiz.controllers.university.get_university_courses_controller import GetUniversityCoursesController
@@ -13,31 +14,27 @@ from app.stuquiz.entities.university import University
 
 class TestGetUniversityCoursesController(unittest.TestCase):
     def setUp(self) -> None:
+        self.request = MagicMock()
         self.university_model = MagicMock()
         self.controller = GetUniversityCoursesController(self.university_model)
+        self.args = mock.PropertyMock(return_value={'university_id': str(uuid.uuid4())})
+        type(self.request).args = self.args
 
     def tearDown(self) -> None:
+        self.request = None
         self.university_model = None
         self.controller = None
-
-    def testExecute_return400_whenInvalidUniversityID(self):
-        # Arrange
-
-        # Act
-        result = self.controller.execute({'university_id': 'invalid uuid'})
-
-        # Assert
-        self.university_model.get_university_courses.assert_not_called()
-        self.assertEqual(400, result.status_code)
+        self.args = None
 
     def testExecute_return404_whenUniversityDontExist(self):
         # Arrange
         self.university_model.get_university_by_id.return_value = None
 
         # Act
-        result = self.controller.execute({'university_id': str(uuid.uuid4())})
+        result = self.controller.execute(self.request)
 
         # Assert
+        self.args.assert_called_once()
         self.university_model.get_university_courses.assert_not_called()
         self.assertEqual(404, result.status_code)
 
@@ -52,9 +49,10 @@ class TestGetUniversityCoursesController(unittest.TestCase):
         self.university_model.get_university_courses.return_value = [first_course, second_course]
 
         # Act
-        result = self.controller.execute({'university_id': str(uuid.uuid4())})
+        result = self.controller.execute(self.request)
 
         # Assert
+        self.args.assert_called_once()
         self.university_model.get_university_courses.assert_called_once()
         self.assertEqual(200, result.status_code)
         self.assertEqual(expected_result, json.loads(result.data))

--- a/app/tests/controllers/university/test_update_university_controller.py
+++ b/app/tests/controllers/university/test_update_university_controller.py
@@ -3,6 +3,7 @@
 import json
 import unittest
 import uuid
+from unittest import mock
 from unittest.mock import MagicMock
 
 from app.stuquiz.controllers.university.update_university_controller import UpdateUniversityController
@@ -14,103 +15,63 @@ class TestUpdateUniversityController(unittest.TestCase):
     TEST_NEW_NAME = 'New Name'
 
     def setUp(self) -> None:
+        self.request = MagicMock()
         self.university_model = MagicMock()
         self.admin_model = MagicMock()
         self.controller = UpdateUniversityController(self.university_model, self.admin_model)
+        self.args = mock.PropertyMock(return_value={'university_id': self.TEST_UNIVERSITY.id})
+        self.form = mock.PropertyMock(return_value={'name': self.TEST_NEW_NAME})
+        type(self.request).args = self.args
+        type(self.request).form = self.form
 
     def tearDown(self) -> None:
+        self.request = None
         self.university_model = None
         self.admin_model = None
         self.controller = None
-
-    def testExecute_return401_whenAdminNotLoggedIn(self):
-        # Arrange
-        self.admin_model.is_admin_logged_in.return_value = False
-
-        # Act
-        result = self.controller.execute({'name': self.TEST_UNIVERSITY.name, 'university_id': self.TEST_UNIVERSITY.id})
-
-        # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
-        self.university_model.update_university.assert_not_called()
-        self.assertEqual(401, result.status_code)
-
-    def testExecute_return400_whenInvalidUniversityName(self):
-        # Arrange
-        self.admin_model.is_admin_logged_in.return_value = True
-
-        # Act
-        result = self.controller.execute({'name': '', 'university_id': self.TEST_UNIVERSITY.id})
-
-        # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
-        self.university_model.update_university.assert_not_called()
-        self.assertEqual(400, result.status_code)
-
-    def testExecute_return400_whenEmptyUniversityId(self):
-        # Arrange
-        self.admin_model.is_admin_logged_in.return_value = True
-
-        # Act
-        result = self.controller.execute({'name': self.TEST_UNIVERSITY.name, 'university_id': ''})
-
-        # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
-        self.university_model.update_university.assert_not_called()
-        self.assertEqual(400, result.status_code)
-
-    def testExecute_return400_whenInvalidUniversityId(self):
-        # Arrange
-        self.admin_model.is_admin_logged_in.return_value = True
-
-        # Act
-        result = self.controller.execute({'name': self.TEST_UNIVERSITY.name, 'university_id': 'invalid university id'})
-
-        # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
-        self.university_model.update_university.assert_not_called()
-        self.assertEqual(400, result.status_code)
+        self.args = None
+        self.form = None
 
     def testExecute_return404_whenUniversityDoesNotExist(self):
         # Arrange
-        self.admin_model.is_admin_logged_in.return_value = True
         self.university_model.get_university_by_id.return_value = None
 
         # Act
-        result = self.controller.execute({'name': self.TEST_UNIVERSITY.name, 'university_id': self.TEST_UNIVERSITY.id})
+        result = self.controller.execute(self.request)
 
         # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
+        self.args.assert_called_once()
+        self.form.assert_not_called()
         self.university_model.update_university.assert_not_called()
         self.assertEqual(404, result.status_code)
 
     def testExecute_return500_whenDbError(self):
         # Arrange
-        self.admin_model.is_admin_logged_in.return_value = True
         self.university_model.get_university_by_id.return_value = self.TEST_UNIVERSITY
         self.university_model.update_university.return_value = False
 
         # Act
-        result = self.controller.execute({'name': self.TEST_UNIVERSITY.name, 'university_id': self.TEST_UNIVERSITY.id})
+        result = self.controller.execute(self.request)
 
         # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
+        self.args.assert_called_once()
+        self.form.assert_called_once()
         self.university_model.update_university.assert_called_once()
         self.assertEqual(500, result.status_code)
 
     def testExecute_return200_whenUniversityUpdated(self):
         # Arrange
-        self.admin_model.is_admin_logged_in.return_value = True
         self.university_model.get_university_by_id.return_value = self.TEST_UNIVERSITY
         self.university_model.update_university.return_value = True
         new_university = University(self.TEST_UNIVERSITY.id, self.TEST_NEW_NAME)
         expected_body = {}
 
         # Act
-        result = self.controller.execute({'name': self.TEST_NEW_NAME, 'university_id': self.TEST_UNIVERSITY.id})
+        result = self.controller.execute(self.request)
 
         # Assert
-        self.admin_model.is_admin_logged_in.assert_called_once()
+        self.args.assert_called_once()
+        self.form.assert_called_once()
         self.university_model.update_university.assert_called_once_with(new_university)
         self.assertEqual(200, result.status_code)
         self.assertEqual(expected_body, json.loads(result.data))

--- a/app/tests/middlewares/__init__.py
+++ b/app/tests/middlewares/__init__.py
@@ -1,0 +1,2 @@
+# @author Simone Nicol <en0mia.dev@gmail.com>
+# @created 24/07/23

--- a/app/tests/middlewares/test_admin_login_middleware.py
+++ b/app/tests/middlewares/test_admin_login_middleware.py
@@ -1,0 +1,40 @@
+# @author Simone Nicol <en0mia.dev@gmail.com>
+# @created 24/07/23
+import unittest
+from unittest.mock import MagicMock
+
+from app.stuquiz.middlewares.admin_login_middleware import AdminLoginMiddleware
+
+
+class TestAdminLoginMiddleware(unittest.TestCase):
+    def setUp(self) -> None:
+        self.admin_model = MagicMock()
+        self.request = MagicMock()
+        self.middleware = AdminLoginMiddleware(self.admin_model)
+
+    def tearDown(self) -> None:
+        self.admin_model = None
+        self.request = None
+        self.middleware = None
+
+    def testDispatch_return401_whenAdminNotLoggedIn(self):
+        # Arrange
+        self.admin_model.is_admin_logged_in.return_value = False
+
+        # Act
+        result = self.middleware.dispatch(self.request)
+
+        # Assert
+        self.admin_model.is_admin_logged_in.assert_called_once()
+        self.assertEqual(401, result.status_code)
+
+    def testDispatch_returnNone_whenAdminLoggedIn(self):
+        # Arrange
+        self.admin_model.is_admin_logged_in.return_value = True
+
+        # Act
+        result = self.middleware.dispatch(self.request)
+
+        # Assert
+        self.admin_model.is_admin_logged_in.assert_called_once()
+        self.assertIsNone(result)


### PR DESCRIPTION
This PR changes the routing system for our APIs.

We'll now use the [easy-route package](https://github.com/en0mia/easy-route) to define the route and implement the middlewares.

> ⚠️ This PR introduces a breaking change in our routes: previously we used to pass parameters like IDs as URI pieces (for instance: `/universities/<university_id>`), while after these changes we'll use query parameters to pass arguments to our APIs in **some cases**, for instance: `/university?university_id=<university_id>`.
>
> **Why?**
> Before this changes we were taking the parameters into the definition of the route, like:
> ```python
> def route(university_id=None):
>     Controller().execute({'university_id': university_id})
> ```
> Now we are using the middlewares to validate our inputs, so we should be able to get the arguments **after** defining the  route, and it's not possible to do it (or better, we could do it, but we have to re-parse the URI and split each parameters:  too much entropy!🗿☄️).
> Moving our strategy to using the query parameters is in my opinion the best way to approach this problem, since we haven't published our APIs yet, so no SDK can fail!

